### PR TITLE
Security fixes and bug fixes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,13 @@
       "Bash(npm audit *)",
       "Bash(npm info *)",
       "Bash(npm ls *)",
-      "Bash(echo \"Exit code: $?\")"
+      "Bash(echo \"Exit code: $?\")",
+      "Bash(git checkout *)",
+      "Bash(php -l /Users/frank/GitHub/archived/video-central/includes/admin/admin.php)",
+      "Bash(php -l /Users/frank/GitHub/archived/video-central/includes/modules/likes/ajax.php)",
+      "Bash(php -l /Users/frank/GitHub/archived/video-central/includes/playlist/class.ajax.php)",
+      "Bash(php -l /Users/frank/GitHub/archived/video-central/includes/playlist/class.editplaylist.php)",
+      "Bash(php -l /Users/frank/GitHub/archived/video-central/includes/modules/import/vimeo/lib/vimeo.php)"
     ]
   }
 }

--- a/assets/admin/js/source/playlist/collections/videos.js
+++ b/assets/admin/js/source/playlist/collections/videos.js
@@ -16,7 +16,8 @@ Videos = Backbone.Collection.extend({
 		var collection = this;
 
 		return wp.ajax.post( 'video_central_get_playlist_videos', {
-			post_id: settings.postId
+			post_id: settings.postId,
+			_ajax_nonce: settings.nonce
 		}).done(function( videos ) {
 			collection.reset( videos );
 		});

--- a/assets/admin/js/source/playlist/views/content/playlist-browser.js
+++ b/assets/admin/js/source/playlist/views/content/playlist-browser.js
@@ -52,8 +52,9 @@ PlaylistBrowser = wp.Backbone.View.extend({
 	getPlaylists: function() {
 		var view = this;
 
-		wp.ajax.post( 'video_central_playlist_get_playlists', {
-			paged: view._paged
+		wp.ajax.post( 'video_central_get_playlists', {
+			paged: view._paged,
+			_ajax_nonce: videoCentralPlaylistConfig.nonce
 		}).done(function( response ) {
 			view.collection.add( response.playlists );
 

--- a/assets/admin/js/source/playlist/views/content/videos-browser.js
+++ b/assets/admin/js/source/playlist/views/content/videos-browser.js
@@ -53,7 +53,8 @@ VideosBrowser = wp.Backbone.View.extend({
 		var view = this;
 
 		wp.ajax.post( 'video_central_get_videos_for_frame', {
-			paged: view._paged
+			paged: view._paged,
+			_ajax_nonce: videoCentralPlaylistConfig.nonce
 		}).done(function( response ) {
 			view.collection.add( response.videos );
 

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -470,6 +470,12 @@ class Video_Central_Admin
     {
         wp_enqueue_script('suggest');
 
+        // Localize nonces for suggest AJAX endpoints
+        wp_localize_script( 'suggest', 'videoCentralAdmin', array(
+            'suggestVideoNonce' => wp_create_nonce( 'video_central_suggest_video_nonce' ),
+            'suggestUserNonce'  => wp_create_nonce( 'video_central_suggest_user_nonce' ),
+        ) );
+
         // Get the version to use for JS
         $version = video_central_get_version();
 
@@ -609,10 +615,24 @@ class Video_Central_Admin
      */
     public function suggest_video()
     {
+        global $wpdb;
+
+        // Bail if user cannot edit videos
+        if ( ! current_user_can( 'edit_posts' ) ) {
+            wp_die( '0' );
+        }
+
+        // Check the ajax nonce
+        check_ajax_referer( 'video_central_suggest_video_nonce' );
+
+        // Bail early if no request
+        if ( empty( $_REQUEST['q'] ) ) {
+            wp_die( '0' );
+        }
 
         // Try to get some videos
         $videos = get_posts(array(
-            's' => like_escape($_REQUEST['q']),
+            's' => $wpdb->esc_like( sanitize_text_field( $_REQUEST['q'] ) ),
             'post_type' => video_central_get_video_post_type(),
         ));
 

--- a/includes/modules/import/vimeo/lib/vimeo.php
+++ b/includes/modules/import/vimeo/lib/vimeo.php
@@ -128,7 +128,7 @@ class phpVimeo
         if ($this->_cache_enabled == self::CACHE_FILE) {
             $file = $this->_cache_dir.'/'.$hash.'.cache';
             if (file_exists($file)) {
-                return unserialize(file_get_contents($file));
+                return json_decode(file_get_contents($file));
             }
         }
     }
@@ -161,7 +161,7 @@ class phpVimeo
         }
 
         // Regular args
-        $api_params = array('format' => 'php');
+        $api_params = array('format' => 'json');
         if (!empty($method)) {
             $api_params['method'] = $method;
         }
@@ -231,8 +231,8 @@ class phpVimeo
 
         // Return
         if (!empty($method)) {
-            $response = unserialize($response);
-            if ($response->stat == 'ok') {
+            $response = json_decode($response);
+            if ($response && $response->stat == 'ok') {
                 return $response;
             }
             else if ($response->err) {

--- a/includes/modules/import/youtube/class.auto.importer.php
+++ b/includes/modules/import/youtube/class.auto.importer.php
@@ -423,7 +423,8 @@ class Video_Central_Youtube_Auto_Importer extends Video_Central_Youtube_API_Quer
      */
     private function _is_import_request($verify_key = false)
     {
-        extract($this->request_vars['var']);
+        $name  = $this->request_vars['var']['name'];
+        $value = $this->request_vars['var']['value'];
         if (isset($_GET[ $name ]) && $value === sanitize_text_field($_GET[ $name ])) {
             $key = $this->request_vars['key'];
             if (isset($_GET[ $key['name'] ])) {

--- a/includes/modules/import/youtube/class.importer.php
+++ b/includes/modules/import/youtube/class.importer.php
@@ -47,6 +47,11 @@ class Video_Central_Youtube_Importer extends Video_Central_Video_Importer
      */
     public function import_videos()
     {
+        // Verify the user has permission to import
+        if ( ! current_user_can( 'publish_posts' ) ) {
+            return false;
+        }
+
         $this->post_type = video_central_get_video_post_type();
 
         if (!isset($_POST['video_central_import']) || !$_POST['video_central_import']) {
@@ -78,7 +83,7 @@ class Video_Central_Youtube_Importer extends Video_Central_Video_Importer
         }
 
         // prepare array of video IDs
-        $video_ids = array_reverse((array) $_POST['video_central_import']);
+        $video_ids = array_map( 'sanitize_text_field', array_reverse( (array) $_POST['video_central_import'] ) );
 
         $total_videos = count($video_ids);
 
@@ -100,21 +105,23 @@ class Video_Central_Youtube_Importer extends Video_Central_Video_Importer
 
         //set category
         if (isset($_REQUEST['cat_top']) && 'import' == $_REQUEST['action_top']) {
-            $category = $_REQUEST['cat_top'];
+            $category = absint( $_REQUEST['cat_top'] );
         } elseif (isset($_REQUEST['cat2']) && 'import' == $_REQUEST['action2']) {
-            $category = $_REQUEST['cat2'];
+            $category = absint( $_REQUEST['cat2'] );
         }
 
-        if (-1 == $category || 0 == $category) {
+        if ( ! $category || -1 == $category ) {
+            $category = false;
+        } elseif ( $category && ! term_exists( $category, $taxonomy ) ) {
             $category = false;
         }
 
         // set user
         $user = false;
         if (isset($_REQUEST['user_top']) && $_REQUEST['user_top']) {
-            $user = (int) $_REQUEST['user_top'];
+            $user = absint( $_REQUEST['user_top'] );
         } elseif (isset($_REQUEST['user2']) && $_REQUEST['user2']) {
-            $user = (int) $_REQUEST['user2'];
+            $user = absint( $_REQUEST['user2'] );
         }
 
         if ($user) {

--- a/includes/modules/likes/ajax.php
+++ b/includes/modules/likes/ajax.php
@@ -24,6 +24,28 @@ class Video_Central_Likes_Ajax
     }
 
     /**
+     * Validate post ID from request: must be an integer and a valid video post.
+     *
+     * @since 1.3.2
+     *
+     * @param mixed $raw_id Raw POST value.
+     * @return int|false Sanitized post ID or false on failure.
+     */
+    private function validate_video_id( $raw_id ) {
+        $id = absint( $raw_id );
+
+        if ( ! $id ) {
+            return false;
+        }
+
+        if ( get_post_type( $id ) !== video_central_get_video_post_type() ) {
+            return false;
+        }
+
+        return $id;
+    }
+
+    /**
      * Fired when a like is triggered for incrementing the post's like count.
      *
      * @since 1.0.0
@@ -52,12 +74,22 @@ class Video_Central_Likes_Ajax
             )));
         }
 
+        $id = $this->validate_video_id( isset( $_POST['id'] ) ? $_POST['id'] : 0 );
+        if ( ! $id ) {
+            wp_die(json_encode(array(
+                'success' => false,
+                'time' => time(),
+                'count' => 0,
+                'message' => 'invalid post',
+            )));
+        }
+
         // increment like count in database
-        $count = get_post_meta($_POST['id'], '_video_central_video_likes_count', true);
+        $count = get_post_meta($id, '_video_central_video_likes_count', true);
         if (empty($count) || $count < 0) {
             $count = 0;
         }
-        update_post_meta($_POST['id'], '_video_central_video_likes_count', ++$count);
+        update_post_meta($id, '_video_central_video_likes_count', ++$count);
 
         // return results
         echo json_encode(array(
@@ -99,15 +131,25 @@ class Video_Central_Likes_Ajax
             )));
         }
 
+        $id = $this->validate_video_id( isset( $_POST['id'] ) ? $_POST['id'] : 0 );
+        if ( ! $id ) {
+            wp_die(json_encode(array(
+                'success' => false,
+                'time' => time(),
+                'count' => 0,
+                'message' => 'invalid post',
+            )));
+        }
+
         // decrement like count in database
-        $count = get_post_meta($_POST['id'], '_video_central_video_likes_count', true);
+        $count = get_post_meta($id, '_video_central_video_likes_count', true);
         if (empty($count) || $count <= 0) {
             $count = 1;
         }
         if ($count == 1) {
-            delete_post_meta($_POST['id'], '_video_central_video_likes_count');
+            delete_post_meta($id, '_video_central_video_likes_count');
         } else {
-            update_post_meta($_POST['id'], '_video_central_video_likes_count', --$count);
+            update_post_meta($id, '_video_central_video_likes_count', --$count);
         }
 
         // return results
@@ -149,8 +191,13 @@ class Video_Central_Likes_Ajax
         }
 
         $counts = array();
-        foreach ($_POST['ids'] as $id) {
-            $counts[$id] = get_video_central_likes_count($id);
+        if ( isset( $_POST['ids'] ) && is_array( $_POST['ids'] ) ) {
+            foreach ($_POST['ids'] as $raw_id) {
+                $id = absint( $raw_id );
+                if ( $id ) {
+                    $counts[ $id ] = get_video_central_likes_count( $id );
+                }
+            }
         }
 
         // return results

--- a/includes/playlist/class.ajax.php
+++ b/includes/playlist/class.ajax.php
@@ -27,6 +27,12 @@ class Video_Central_Playlist_Ajax {
 	 * @since 1.3.0
 	 */
 	public function get_videos_for_frame() {
+		check_ajax_referer( 'video_central_playlist_nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error();
+		}
+
 		$data = array();
 		$page = isset( $_POST['paged'] ) ? absint( $_POST['paged'] ) : 1;
 		$posts_per_page = isset( $_POST['posts_per_page'] ) ? absint( $_POST['posts_per_page'] ) : 40;
@@ -62,6 +68,12 @@ class Video_Central_Playlist_Ajax {
 	 * @since 2.2.0
 	 */
 	public function get_playlists() {
+		check_ajax_referer( 'video_central_playlist_nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error();
+		}
+
 		$data = array();
 		$page = isset( $_POST['paged'] ) ? absint( $_POST['paged'] ) : 1;
 		$posts_per_page = isset( $_POST['posts_per_page'] ) ? absint( $_POST['posts_per_page'] ) : 40;
@@ -97,7 +109,18 @@ class Video_Central_Playlist_Ajax {
 	 * @since 2.0.0
 	 */
 	public function get_playlist_videos() {
+		check_ajax_referer( 'video_central_playlist_nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error();
+		}
+
 		$post_id = absint( $_POST['post_id'] );
+
+		if ( ! $post_id || get_post_type( $post_id ) !== 'video_central_playlist' ) {
+			wp_send_json_error();
+		}
+
 		wp_send_json_success( video_central_get_playlist_videos( $post_id, 'edit' ) );
 	}
 
@@ -150,13 +173,19 @@ class Video_Central_Playlist_Ajax {
 
 		check_ajax_referer( 'video_central_parse_shortcode' );
 
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error();
+		}
+
 		if ( empty( $_POST['shortcode'] ) ) {
 			wp_send_json_error();
 		}
 
 		$shortcode = wp_unslash( $_POST['shortcode'] );
 
-		if ( 0 !== strpos( $shortcode, '[video_central_playlist ' ) ) {
+		// Validate that the input contains exactly one video_central_playlist shortcode
+		// and nothing else, to prevent shortcode injection.
+		if ( ! preg_match( '/^\[video_central_playlist\s[^\]]*\]$/', $shortcode ) ) {
 			wp_send_json_error();
 		}
 
@@ -174,11 +203,10 @@ class Video_Central_Playlist_Ajax {
 
 		// @codingStandardsIgnoreStart
 		foreach ( $styles as $style ) {
-			$head .= '<link type="text/css" rel="stylesheet" href="' . $style . '">'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-
+			$head .= '<link type="text/css" rel="stylesheet" href="' . esc_url( $style ) . '">';
 		}
 
-		$head .= '<link rel="stylesheet" href="' . $this->plugin->get_url( 'assets/css/video-central-playlist.min.css' ) . '">'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$head .= '<link rel="stylesheet" href="' . esc_url( $this->plugin->get_url( 'assets/css/video-central-playlist.min.css' ) ) . '">';
 		$head .= '<style type="text/css">.video-central-playlist-videos { max-height: none;}</style>';
 		// @codingStandardsIgnoreEnd
 

--- a/includes/playlist/class.editplaylist.php
+++ b/includes/playlist/class.editplaylist.php
@@ -109,6 +109,7 @@ class Video_Central_Playlist_EditPlaylist {
 		wp_localize_script( 'video-central-playlist-playlist-edit', 'videoCentralPlaylistConfig', array(
 			'postId'     => $post->ID,
 			'saveNonce'  => wp_create_nonce( 'save-videos_' . $post->ID ),
+			'nonce'      => wp_create_nonce( 'video_central_playlist_nonce' ),
 			'videos'     => video_central_get_playlist_videos( $post->ID, 'edit' ),
 			'l10n'       => array(
 				'addVideos'  => esc_html__( 'Add Videos', 'video_central' ),


### PR DESCRIPTION
   Security fixes:

  1. admin.php: suggest_video AJAX — Added nonce verification, capability check (edit_posts), replaced deprecated like_escape() with $wpdb->esc_like(sanitize_text_field()), added nonce localization for both suggest endpoints
  2. likes/ajax.php: like/unlike — Added validate_video_id() that calls absint() and verifies the post is the correct post type before allowing meta operations
  3. likes/ajax.php: likes_count — Cast each ID via absint(), added is_array() guard on $_POST['ids']
  4. playlist/class.ajax.php: read endpoints — Added check_ajax_referer('video_central_playlist_nonce') and current_user_can('edit_posts') to get_playlists(), get_videos_for_frame(), and get_playlist_videos(); added post type validation on get_playlist_videos()
  5. playlist/class.ajax.php: parse_shortcode — Replaced loose strpos prefix check with strict regex /^\[video_central_playlist\s[^\]]*\]$/ to prevent shortcode injection; added capability check; added esc_url() to stylesheet hrefs
  6. vimeo/lib/vimeo.php: unsafe deserialization — Switched API format from php to json; replaced both unserialize() calls with json_decode()
  7. youtube/class.importer.php: import_videos — Added current_user_can('publish_posts') check; sanitized video IDs with sanitize_text_field(); sanitized category/user inputs with absint() and validated term existence
  8. youtube/class.auto.importer.php: variable injection — Replaced extract($this->request_vars['var']) with explicit variable assignment

  Bug fix:

  9. playlist-browser.js — Fixed wrong AJAX action name video_central_playlist_get_playlists to video_central_get_playlists

  Supporting changes:

  10. class.editplaylist.php — Added video_central_playlist_nonce to localized script config
  11. collections/videos.js, videos-browser.js, playlist-browser.js — Added _ajax_nonce parameter to all playlist AJAX calls